### PR TITLE
remove clownfish-pylcommon dependency from rpm spec #3

### DIFF
--- a/lond.spec.in
+++ b/lond.spec.in
@@ -20,7 +20,6 @@ License: GPLv2
 Group: Applications/System
 Source0: @PACKAGE@-%{version}.tar.gz
 BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
-Requires: clownfish-pylcommon
 Requires: lustre
 Provides: lond = %{version}-%{release}
 %if %{with systemd}


### PR DESCRIPTION
Since we included pylcommon libs, it's time to remove the dependency from  clownfish-pylcommon package.

Signed-off-by: Gu Zheng <gzheng@ddn.com>